### PR TITLE
Lower minimum CMake version

### DIFF
--- a/byond-extools/CMakeLists.txt
+++ b/byond-extools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15.0)
+cmake_minimum_required(VERSION 3.10.0)
 project(byond-extools)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/byond-extools/CMakeLists.txt
+++ b/byond-extools/CMakeLists.txt
@@ -1,4 +1,10 @@
-cmake_minimum_required(VERSION 3.10.0)
+if (WIN32)
+    # Needed for MSVC_RUNTIME_LIBRARY
+    cmake_minimum_required(VERSION 3.15.0)
+else()
+    cmake_minimum_required(VERSION 3.10.0)
+endif()
+
 project(byond-extools)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
bionic only packages 3.10.2, didn't notice any obviously-cmake problems doing this