### PR TITLE
Add continuous integration scripts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,13 @@
+pull_requests:
+  do_not_increment_build_number: true
+version: '{build}'
+branches:
+  only:
+  - master
+shallow_clone: true
+image: Visual Studio 2017
+build_script:
+  - mkdir build
+  - cd build
+  - cmake ../byond-extools
+  - cmake --build .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+dist: bionic
+branches:
+  only:
+    - master
+script:
+  - mkdir build
+  - cd build
+  - cmake ../byond-extools -DCMAKE_TOOLCHAIN_FILE=../byond-extools/cmake/i686-w64-mingw32.cmake
+  - cmake --build .


### PR DESCRIPTION
- Appveyor for native Windows builds
- Travis for Linux-to-Windows cross-compiled builds

Should be as simple as signing in to these services and hitting the "enable" button.