### PR TITLE
Fix cross-compile errors and warnings

### DIFF
--- a/byond-extools/src/core/core.cpp
+++ b/byond-extools/src/core/core.cpp
@@ -47,7 +47,7 @@ bool Core::initialize()
 
 void Core::Alert(std::string what) {
 #ifdef _WIN32
-	MessageBoxA(NULL, what.c_str(), "Ouch!", NULL);
+	MessageBoxA(NULL, what.c_str(), "Ouch!", MB_OK);
 #else
 	printf("%s\n", what);
 #endif

--- a/byond-extools/src/core/socket/socket.cpp
+++ b/byond-extools/src/core/socket/socket.cpp
@@ -120,7 +120,7 @@ bool SocketServer::send(nlohmann::json j)
 	data.push_back(0);
 	while (!data.empty())
 	{
-		int sent_bytes = ::send(client_socket, data.c_str(), data.size(), NULL);
+		int sent_bytes = ::send(client_socket, data.c_str(), data.size(), 0);
 		if (sent_bytes == SOCKET_ERROR)
 		{
 			return false;
@@ -142,7 +142,7 @@ nlohmann::json SocketServer::recv_message()
 			return json;
 		}
 
-		int received_bytes = ::recv(client_socket, data.data(), data.size(), NULL);
+		int received_bytes = ::recv(client_socket, data.data(), data.size(), 0);
 		if (received_bytes == 0) {
 			return nlohmann::json();
 		}

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -67,7 +67,7 @@ void DebugServer::debug_loop()
 			std::vector<nlohmann::json> instructions;
 			for (Instruction& instr : disassembly.instructions)
 			{
-				std::string& comment = instr.comment();
+				std::string comment = instr.comment();
 				stripUnicode(comment);
 				nlohmann::json d_instr = {
 					{ "offset", instr.offset() },
@@ -193,7 +193,7 @@ bool place_restorer_on_next_instruction(ExecutionContext* ctx, std::uint16_t off
 bool place_breakpoint_on_next_instruction(ExecutionContext* ctx, unsigned int offset) //TODO: make this and the above better
 {
 	Core::Proc p = Core::get_proc(ctx->constants->proc_id);
-	Disassembly current_dis = Disassembler(reinterpret_cast<std::uint32_t*>(ctx->bytecode), p.get_bytecode_length(), procs_by_id).disassemble();
+	Disassembly current_dis = Disassembler(ctx->bytecode, p.get_bytecode_length(), procs_by_id).disassemble();
 	Instruction* next = current_dis.next_from_offset(offset);
 	if (next)
 	{

--- a/byond-extools/src/dmdism/disassembler.cpp
+++ b/byond-extools/src/dmdism/disassembler.cpp
@@ -21,6 +21,11 @@ Disassembler::Disassembler(std::uint32_t* bc, unsigned int bc_len, std::vector<C
 	context_ = new Context(v, ps);
 }
 
+Disassembler::~Disassembler()
+{
+	delete context_;
+}
+
 Disassembly Disassembler::disassemble()
 {
 	std::vector<Instruction> instrs;

--- a/byond-extools/src/dmdism/disassembler.h
+++ b/byond-extools/src/dmdism/disassembler.h
@@ -18,7 +18,7 @@ public:
 	Disassembler(std::uint32_t* bc, unsigned int bc_len, std::vector<Core::Proc>& ps);
 	Disassembly disassemble();
 
-	~Disassembler() { delete context_; }
+	~Disassembler();
 
 	Context* context() const { return context_; }
 
@@ -28,6 +28,6 @@ public:
 
 private:
 	Context* context_;
-	
+
 	Instruction disassemble_next();
 };


### PR DESCRIPTION
- Fix bad assignment of temporary to reference
- Use 0 instead of NULL in non-pointer contexts
- Fix 'invalid use of incomplete type' warnings