### PR TITLE
Fix cross-compile errors

### DIFF
--- a/byond-extools/src/core/hooking.cpp
+++ b/byond-extools/src/core/hooking.cpp
@@ -54,7 +54,7 @@ void Core::remove_hook(void* func)
 
 
 bool Core::hook_custom_opcodes() {
-	oCrashProc = (CrashProcPtr)install_hook(CrashProc, hCrashProc);
-	oCallGlobalProc = (CallGlobalProcPtr)install_hook(CallGlobalProc, hCallGlobalProc);
+	oCrashProc = (CrashProcPtr)install_hook((void*)CrashProc, (void*)hCrashProc);
+	oCallGlobalProc = (CallGlobalProcPtr)install_hook((void*)CallGlobalProc, (void*)hCallGlobalProc);
 	return oCrashProc && oCallGlobalProc;
 }

--- a/byond-extools/src/dmdism/disassembly.cpp
+++ b/byond-extools/src/dmdism/disassembly.cpp
@@ -3,11 +3,11 @@
 
 // Older GCC compilers don't have C++20 support yet.
 #if __cplusplus > 201703L
-using std::lower_bound;
+using local_lower_bound = std::lower_bound;
 #else
 // "Second version" from https://en.cppreference.com/w/cpp/algorithm/lower_bound
 template<class ForwardIt, class T, class Compare>
-ForwardIt lower_bound(ForwardIt first, ForwardIt last, const T& value, Compare comp)
+ForwardIt local_lower_bound(ForwardIt first, ForwardIt last, const T& value, Compare comp)
 {
     ForwardIt it;
     typename std::iterator_traits<ForwardIt>::difference_type count, step;
@@ -47,7 +47,7 @@ Instruction& Disassembly::at(std::size_t i)
 
 Instruction* Disassembly::next_from_offset(std::uint16_t offset)
 {
-	auto it = lower_bound(instructions.begin(), instructions.end(), offset, [](Instruction const& instr, int offset) { return instr.offset() < offset; });
+	auto it = local_lower_bound(instructions.begin(), instructions.end(), offset, [](Instruction const& instr, int offset) { return instr.offset() < offset; });
 
 	if (it == instructions.end() || ++it == instructions.end())
 	{

--- a/byond-extools/src/dmdism/disassembly.cpp
+++ b/byond-extools/src/dmdism/disassembly.cpp
@@ -1,6 +1,33 @@
 #include "disassembly.h"
 #include "disassembler.h"
 
+// Older GCC compilers don't have C++20 support yet.
+#if __cplusplus > 201703L
+using std::lower_bound;
+#else
+// "Second version" from https://en.cppreference.com/w/cpp/algorithm/lower_bound
+template<class ForwardIt, class T, class Compare>
+ForwardIt lower_bound(ForwardIt first, ForwardIt last, const T& value, Compare comp)
+{
+    ForwardIt it;
+    typename std::iterator_traits<ForwardIt>::difference_type count, step;
+    count = std::distance(first, last);
+
+    while (count > 0) {
+        it = first;
+        step = count / 2;
+        std::advance(it, step);
+        if (comp(*it, value)) {
+            first = ++it;
+            count -= step + 1;
+        }
+        else
+            count = step;
+    }
+    return first;
+}
+#endif
+
 std::vector<std::uint32_t>* Disassembly::assemble()	{
 	std::vector<std::uint32_t>* ret = new std::vector<std::uint32_t>();
 	for (Instruction i : instructions)
@@ -20,7 +47,7 @@ Instruction& Disassembly::at(std::size_t i)
 
 Instruction* Disassembly::next_from_offset(std::uint16_t offset)
 {
-	auto it = std::lower_bound(instructions.begin(), instructions.end(), offset, [](Instruction const& instr, int offset) { return instr.offset() < offset; });
+	auto it = lower_bound(instructions.begin(), instructions.end(), offset, [](Instruction const& instr, int offset) { return instr.offset() < offset; });
 
 	if (it == instructions.end() || ++it == instructions.end())
 	{

--- a/byond-extools/src/extended_profiling/extended_profiling.cpp
+++ b/byond-extools/src/extended_profiling/extended_profiling.cpp
@@ -4,7 +4,7 @@
 #include <fstream>
 #include <algorithm>
 #ifdef WIN32
-#include <Windows.h>
+#include <windows.h>
 #else
 #error dump_extended_profile() needs to be able to create a directory on linux
 #endif
@@ -255,9 +255,9 @@ SuspendedProc* hSuspend(ExecutionContext* ctx, int unknown)
 
 bool actual_extended_profiling_initialize()
 {
-	oCreateContext = (CreateContextPtr)Core::install_hook(CreateContext, hCreateContext);
-	oProcCleanup = (ProcCleanupPtr)Core::install_hook(ProcCleanup, hProcCleanup);
-	oSuspend = (SuspendPtr)Core::install_hook(Suspend, hSuspend);
+	oCreateContext = (CreateContextPtr)Core::install_hook((void*)CreateContext, (void*)hCreateContext);
+	oProcCleanup = (ProcCleanupPtr)Core::install_hook((void*)ProcCleanup, (void*)hProcCleanup);
+	oSuspend = (SuspendPtr)Core::install_hook((void*)Suspend, (void*)hSuspend);
 	return oCreateContext && oProcCleanup && oSuspend;
 }
 

--- a/byond-extools/src/proxy/proxy_object.cpp
+++ b/byond-extools/src/proxy/proxy_object.cpp
@@ -67,8 +67,8 @@ trvh install_accessors(unsigned int n_args, Value* args, Value src)
 
 bool Proxy::initialize()
 {
-	oGetVariable = (GetVariablePtr)Core::install_hook(GetVariable, hGetVariable);
-	oSetVariable = (SetVariablePtr)Core::install_hook(SetVariable, hSetVariable);
+	oGetVariable = (GetVariablePtr)Core::install_hook((void*)GetVariable, (void*)hGetVariable);
+	oSetVariable = (SetVariablePtr)Core::install_hook((void*)SetVariable, (void*)hSetVariable);
 	if (false)
 	{
 		Core::get_proc("/datum/proxy_object/proc/__install").hook(install_proxy);


### PR DESCRIPTION
- Fix non-standard implicit conversions of function pointers to `void*`.
- Fix `windows.h` capitalization.
- Add `lower_bound` fallback for old versions of GCC without C++2a support.