### PR TITLE
Move single-step hook to a .s file for GCC

### DIFF
--- a/byond-extools/CMakeLists.txt
+++ b/byond-extools/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
     cmake_minimum_required(VERSION 3.10.0)
 endif()
 
-project(byond-extools)
+project(byond-extools CXX C ASM)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
@@ -14,6 +14,7 @@ file(GLOB_RECURSE SRC_FILES
     "${SRC_DIR}/*.cpp"
     "${SRC_DIR}/*.h"
     "${SRC_DIR}/*.hpp"
+    "${SRC_DIR}/*.s"
 )
 set(SRC_FILES ${SRC_FILES} "${SRC_DIR}/core/subhook/subhook.c")
 

--- a/byond-extools/CMakeLists.txt
+++ b/byond-extools/CMakeLists.txt
@@ -5,7 +5,8 @@ else()
     cmake_minimum_required(VERSION 3.10.0)
 endif()
 
-project(byond-extools CXX C ASM)
+project(byond-extools)
+enable_language(ASM)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -441,7 +441,24 @@ void on_breakpoint(ExecutionContext* ctx)
 	debug_server.on_breakpoint(ctx);
 }
 
-extern "C" void* singlestep_hook;
+#ifdef _MSC_VER
+__declspec(naked) void singlestep_hook()
+{
+	_asm
+	{
+		// If you modify this, modify singlestep_hook.s as well.
+		push eax
+		mov edx, on_singlestep
+		call edx
+		pop eax
+		MOVZX ECX, WORD PTR DS : [EAX + 0x14]
+		MOV EDI, DWORD PTR DS : [EAX + 0x10]
+		ret
+	}
+}
+#else
+extern "C" void singlestep_hook();
+#endif
 
 /*
 MOVZX ECX, WORD PTR DS:[EAX + 0x14]

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -417,7 +417,7 @@ void hRuntime(char* error)
 	oRuntime(error);
 }
 
-void on_singlestep()
+extern "C" void on_singlestep()
 {
 	if (debug_server.breakpoint_to_restore && Core::get_context()->current_opcode != debug_server.breakpoint_to_restore->offset)
 	{
@@ -441,19 +441,7 @@ void on_breakpoint(ExecutionContext* ctx)
 	debug_server.on_breakpoint(ctx);
 }
 
-__declspec(naked) void singlestep_hook()
-{
-	_asm
-	{
-		push eax
-		mov edx, on_singlestep
-		call edx
-		pop eax
-		MOVZX ECX, WORD PTR DS : [EAX + 0x14]
-		MOV EDI, DWORD PTR DS : [EAX + 0x10]
-		ret
-	}
-}
+extern "C" void* singlestep_hook;
 
 /*
 MOVZX ECX, WORD PTR DS:[EAX + 0x14]

--- a/byond-extools/src/debug_server/singlestep_hook.s
+++ b/byond-extools/src/debug_server/singlestep_hook.s
@@ -1,6 +1,8 @@
 .intel_syntax
 .global _singlestep_hook
 _singlestep_hook:
+
+    // If you modify this, modify the inline assembly in debug_server.cpp as well.
     push eax
     mov edx, _on_singlestep
     call edx

--- a/byond-extools/src/debug_server/singlestep_hook.s
+++ b/byond-extools/src/debug_server/singlestep_hook.s
@@ -1,0 +1,10 @@
+.intel_syntax
+.global _singlestep_hook
+_singlestep_hook:
+    push eax
+    mov edx, _on_singlestep
+    call edx
+    pop eax
+    MOVZX ECX, WORD PTR DS : [EAX + 0x14]
+    MOV EDI, DWORD PTR DS : [EAX + 0x10]
+    ret


### PR DESCRIPTION
GCC <8 does not support naked functions on x86.