### PR TITLE
Refine debugger protocol

### DIFF
--- a/byond-extools/src/core/core.h
+++ b/byond-extools/src/core/core.h
@@ -11,6 +11,7 @@
 #include <map>
 #include <string>
 #include <cmath>
+#include <vector>
 
 #ifdef _WIN32
 #define EXPORT __declspec(dllexport)

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -421,7 +421,8 @@ nlohmann::json value_to_text(Value val)
 	case DATUM_TYPEPATH:
 	case LIST_TYPEPATH:
 	case CLIENT_TYPEPATH:
-		// TODO
+		literal = { { "typepath", Core::type_to_text(val.value) } };
+		break;
 	case RESOURCE:
 		// TODO
 	default:

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -409,6 +409,19 @@ nlohmann::json value_to_text(Value val)
 	case STRING:
 		literal = { { "string", GetStringTableEntry(val.value)->stringData } };
 		break;
+	case MOB_TYPEPATH:
+		literal = { { "typepath", Core::type_to_text(*MobTableIndexToGlobalTableIndex(val.value)) } };
+		break;
+	case OBJ_TYPEPATH:
+	case TURF_TYPEPATH:
+	case AREA_TYPEPATH:
+	case DATUM_TYPEPATH:
+	case LIST_TYPEPATH:
+	case CLIENT_TYPEPATH:
+		// TODO
+	case RESOURCE:
+		// TODO
+	default:
 		literal = { { "ref", (val.type << 24) | val.value } };
 	}
 	nlohmann::json result = { { "literal", literal } };

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -139,6 +139,13 @@ int DebugServer::handle_one_message()
 		next_action = STEP_OVER;
 		notifier.notify_all();
 	}
+	else if (type == MESSAGE_BREAKPOINT_PAUSE)
+	{
+		std::lock_guard<std::mutex> lk(notifier_mutex);
+		debug_server.step_mode = StepMode::INTO;
+		next_action = STEP_INTO;
+		notifier.notify_all();
+	}
 	else if (type == MESSAGE_BREAKPOINT_RESUME)
 	{
 		std::lock_guard<std::mutex> lk(notifier_mutex);

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -419,9 +419,15 @@ nlohmann::json value_to_text(Value val)
 	case TURF_TYPEPATH:
 	case AREA_TYPEPATH:
 	case DATUM_TYPEPATH:
-	case LIST_TYPEPATH:
-	case CLIENT_TYPEPATH:
 		literal = { { "typepath", Core::type_to_text(val.value) } };
+		break;
+	case LIST_TYPEPATH:
+		// Not subtypeable
+		literal = { { "typepath", "/list" } };
+		break;
+	case CLIENT_TYPEPATH:
+		// Not subtypeable
+		literal = { { "typepath", "/client" } };
 		break;
 	case RESOURCE:
 		// TODO

--- a/byond-extools/src/debug_server/debug_server.cpp
+++ b/byond-extools/src/debug_server/debug_server.cpp
@@ -140,10 +140,7 @@ int DebugServer::handle_one_message()
 	}
 	else if (type == MESSAGE_BREAKPOINT_PAUSE)
 	{
-		std::lock_guard<std::mutex> lk(notifier_mutex);
 		debug_server.step_mode = StepMode::INTO;
-		next_action = STEP_INTO;
-		notifier.notify_all();
 	}
 	else if (type == MESSAGE_BREAKPOINT_RESUME)
 	{

--- a/byond-extools/src/debug_server/protocol.h
+++ b/byond-extools/src/debug_server/protocol.h
@@ -140,6 +140,7 @@ struct VariableWrite
 #define MESSAGE_BREAKPOINT_STEP_INTO "breakpoint step into" //Content is empty
 #define MESSAGE_BREAKPOINT_STEP_OVER "breakpoint step over" //Content is empty
 #define MESSAGE_BREAKPOINT_RESUME "breakpoint resume" //Content is empty
+#define MESSAGE_BREAKPOINT_PAUSE "breakpoint pause"
 #define MESSAGE_VALUES_LOCALS "locals" //Content is a vector of ValueTexts
 #define MESSAGE_VALUES_ARGS "args" //^
 #define MESSAGE_VALUES_STACK "stack" //^


### PR DESCRIPTION
- Add more useful information to ValueText type
- Use numeric references rather than (string kind name, int id) pairs
- Add "breakpoint pause" message
- Consistently use "proc" instead of "name" and "offset" instead of "instruction_pointer"