### PR TITLE
Export memory profiler

### DIFF
--- a/byond-extools/src/dm/_extools_api.dm
+++ b/byond-extools/src/dm/_extools_api.dm
@@ -169,3 +169,7 @@ var/next_promise_id = 0
 	
 /proc/disable_profiling()
 	return call(EXTOOLS, "disable_profiling")() == EXTOOLS_SUCCESS
+
+// Will dump the server's in-depth memory profile into the file specified.
+/proc/dump_memory_profile(file_name)
+	return call(EXTOOLS, "dump_memory_usage")(file_name) == EXTOOLS_SUCCESS

--- a/byond-extools/src/extended_profiling/extended_profiling_exports.cpp
+++ b/byond-extools/src/extended_profiling/extended_profiling_exports.cpp
@@ -1,5 +1,6 @@
 #include "../core/core.h"
 #include "extended_profiling.h"
+#include "memory_profiling.h"
 
 // TODO: make this work on Linux. -steamport
 extern "C" EXPORT const char* extended_profiling_initialize(int n_args, const char** args)
@@ -19,5 +20,14 @@ extern "C" EXPORT const char* enable_extended_profiling(int n_args, const char**
 extern "C" EXPORT const char* disable_extended_profiling(int n_args, const char** args)
 {
 	procs_to_profile.erase(Core::get_proc(args[0]).id); //TODO: improve consistency and reconsider how initialization works
+	return Core::SUCCESS;
+}
+
+extern "C" EXPORT const char* dump_memory_usage(int n_args, const char** args)
+{
+	if (!Core::initialize())
+		return Core::FAIL;
+
+	dump_full_obj_mem_usage(args[0]);
 	return Core::SUCCESS;
 }

--- a/byond-extools/src/extended_profiling/memory_profiling.cpp
+++ b/byond-extools/src/extended_profiling/memory_profiling.cpp
@@ -297,7 +297,7 @@ void to_json(nlohmann::json& j, const DatumMemUsagePerType& dmu)
 	};
 }
 
-void dump_full_obj_mem_usage()
+void dump_full_obj_mem_usage(const std::string& fname)
 {
 	nlohmann::json objs = get_full_obj_mem_usage();
 	nlohmann::json datums = get_full_datum_mem_usage();
@@ -308,6 +308,6 @@ void dump_full_obj_mem_usage()
 	everything["mobs"] = mobs;
 	everything["total"] = objs["total"].get<unsigned int>() + datums["total"].get<unsigned int>() + mobs["total"].get<unsigned int>();
 	everything["total_instances"] = objs["total_instances"].get<unsigned int>() + datums["total_instances"].get<unsigned int>() + mobs["total_instances"].get<unsigned int>();
-	std::ofstream o("memdump.json");
+	std::ofstream o(fname);
 	o << std::setw(2) << everything;
 }

--- a/byond-extools/src/extended_profiling/memory_profiling.h
+++ b/byond-extools/src/extended_profiling/memory_profiling.h
@@ -130,4 +130,4 @@ FullMemUsage<DatumMemUsagePerType> get_full_datum_mem_usage();
 FullListMemUsage get_full_list_mem_usage();
 FullMemUsage<MobMemUsagePerType> get_full_mob_mem_usage();
 
-void dump_full_obj_mem_usage();
+void dump_full_obj_mem_usage(const std::string& fname);


### PR DESCRIPTION
Exports the memory profile feature.

Modifies the `dump_full_obj_mem_usage` function to accept a destination path as a string. An exposes it as an exported function.