### PR TITLE
fix bytecode_idx and local_var(_count?)_idx datatypes

### DIFF
--- a/byond-extools/src/core/byond_structures.h
+++ b/byond-extools/src/core/byond_structures.h
@@ -279,8 +279,8 @@ struct ProcArrayEntry
 	int procCategory;
 	int procFlags;
 	int unknown1;
-	unsigned short bytecode_idx; // ProcSetupEntry index
-	unsigned short local_var_count_idx; // ProcSetupEntry index
+	int bytecode_idx; // ProcSetupEntry index
+	int local_var_count_idx; // ProcSetupEntry index
 	int unknown2;
 };
 

--- a/byond-extools/src/core/proc_management.h
+++ b/byond-extools/src/core/proc_management.h
@@ -33,8 +33,8 @@ namespace Core
 		ProcSetupEntry* setup_entry_bytecode = nullptr;
 		ProcSetupEntry* setup_entry_varcount = nullptr;
 
-		std::uint16_t bytecode_idx = 0;
-		std::uint16_t varcount_idx = 0;
+		std::uint32_t bytecode_idx = 0;
+		std::uint32_t varcount_idx = 0;
 
 		std::uint32_t* original_bytecode_ptr = nullptr;
 		std::vector<std::uint32_t> bytecode;


### PR DESCRIPTION
so that procs with a big index can have a breakpoint set on them with the debugger